### PR TITLE
Fix metadataBase warning for social previews

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -16,6 +16,7 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Promptic",
   description: "AI Prompt Management Platform",
+  metadataBase: new URL('https://promptic.app'),
   openGraph: {
     title: "Promptic",
     description: "AI Prompt Management Platform",


### PR DESCRIPTION
Fixes the metadataBase warning by setting the proper URL for social media previews.

Error message:
`⚠ metadataBase property in metadata export is not set for resolving social open graph or twitter images, using "http://localhost:3000"`